### PR TITLE
feat!: Migrate the package to ESM

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,5 +1,0 @@
-module.exports = {
-  require: ['ts-node/register'],
-  forbidOnly: Boolean(process.env.CI),
-  color: true,
-};

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
-import {DevtoolsPlugin} from './plugin';
+import {DevtoolsPlugin} from './plugin.js';
 
 export {DevtoolsPlugin};
 export default DevtoolsPlugin;

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,3 +1,3 @@
-import {logger} from 'appium/support';
+import {logger} from 'appium/support.js';
 
 export const log = logger.getLogger('DevtoolsPlugin');

--- a/lib/mixins/atoms.ts
+++ b/lib/mixins/atoms.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import {CDP_REQ_TIMEOUT_MS} from '../constants';
+import {CDP_REQ_TIMEOUT_MS} from '../constants.js';
 
 // https://chromedevtools.github.io/devtools-protocol/
 

--- a/lib/mixins/cmds.ts
+++ b/lib/mixins/cmds.ts
@@ -1,4 +1,4 @@
-import {errors} from 'appium/driver';
+import {errors} from 'appium/driver.js';
 import type {Request} from 'express';
 import {
   cdpInfo,
@@ -8,10 +8,10 @@ import {
   cdpActivateTab,
   cdpCloseTab,
   cdpInspector,
-} from './atoms';
-import {replaceDeep} from '../utils';
-import type {DevtoolsPlugin} from '../plugin';
-import type {ProxiedSession} from '../types';
+} from './atoms.js';
+import {replaceDeep} from '../utils.js';
+import type {DevtoolsPlugin} from '../plugin.js';
+import type {ProxiedSession} from '../types.js';
 
 /**
  * Returns version information for a proxied DevTools target with URL rewrites applied.

--- a/lib/mixins/proxy.ts
+++ b/lib/mixins/proxy.ts
@@ -1,18 +1,19 @@
-import {util} from 'appium/support';
+import {util} from 'appium/support.js';
 import {findAPortNotInUse, checkPortStatus} from 'portscanner';
-import {toSocketNameAlias, fetchInterfaces, V4_BROADCAST_IP, V6_BROADCAST_IP} from '../utils';
-import WebSocket from 'ws';
-import {CDP_METHODS_ROOT} from '../constants';
-import {cdpInfo, cdpList} from './atoms';
-import type {DevtoolsPlugin} from '../plugin';
-import type {BaseDriver} from 'appium/driver';
+import {toSocketNameAlias, fetchInterfaces, V4_BROADCAST_IP, V6_BROADCAST_IP} from '../utils.js';
+import WebSocket, {WebSocketServer} from 'ws';
+import {CDP_METHODS_ROOT} from '../constants.js';
+import {cdpInfo, cdpList} from './atoms.js';
+import type {DevtoolsPlugin} from '../plugin.js';
+import type {BaseDriver} from 'appium/driver.js';
 import type {
   RequiredDriverProperties,
   WebviewProps,
   DevtoolsTargetsInfo,
   ProxyInfo,
-} from '../types';
+} from '../types.js';
 import type {IncomingMessage} from 'node:http';
+import type {WSServer} from '@appium/types';
 
 type Driver = BaseDriver<any, any, any, any, any, any>;
 
@@ -207,7 +208,10 @@ export async function proxyDevtoolsTarget(
   ]) {
     await server.addWebSocketHandler(
       fromPathname,
-      prepareWebSocketForwarder.bind(this)(toUrlPattern, placeholder),
+      // 'ws' resolves to different type declarations depending on the module resolution mode
+      // of the consuming package, so the ESM-resolved WebSocketServer type is not structurally
+      // identical to the CJS-resolved one @appium/types expects here.
+      prepareWebSocketForwarder.bind(this)(toUrlPattern, placeholder) as unknown as WSServer,
     );
   }
 
@@ -456,8 +460,8 @@ function prepareWebSocketForwarder(
   this: DevtoolsPlugin,
   forwardToUrlPattern: string,
   entityIdPlaceholder: string,
-): WebSocket.Server {
-  const wss = new WebSocket.Server({
+): WebSocketServer {
+  const wss = new WebSocketServer({
     noServer: true,
   });
   wss.on('connection', (wsUpstream: WebSocket, req: IncomingMessage) => {

--- a/lib/plugin.ts
+++ b/lib/plugin.ts
@@ -1,16 +1,16 @@
-import {BasePlugin} from 'appium/plugin';
-import {util} from 'appium/support';
-import * as proxyMethods from './mixins/proxy';
-import * as cmdMethods from './mixins/cmds';
-import {CDP_METHODS_ROOT} from './constants';
-import {registerPlugin, findPlugin} from './registry';
-import {log as logger} from './logger';
-import type {BaseDriver} from 'appium/driver';
+import {BasePlugin} from 'appium/plugin.js';
+import {util} from 'appium/support.js';
+import * as proxyMethods from './mixins/proxy.js';
+import * as cmdMethods from './mixins/cmds.js';
+import {CDP_METHODS_ROOT} from './constants.js';
+import {registerPlugin, findPlugin} from './registry.js';
+import {log as logger} from './logger.js';
+import type {BaseDriver} from 'appium/driver.js';
 import type {ExecuteMethodMap, Plugin, PluginCommand} from '@appium/types';
 
 type Driver = BaseDriver<any, any, any, any, any, any>;
 import type {Express, Request, Response} from 'express';
-import type {ProxiedSession} from './types';
+import type {ProxiedSession} from './types.js';
 
 type DevtoolsPluginMapType = Plugin & Record<string, PluginCommand>;
 

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -1,4 +1,4 @@
-import type {DevtoolsPlugin} from './plugin';
+import type {DevtoolsPlugin} from './plugin.js';
 
 export const PLUGIN_INSTANCES = new Set<WeakRef<DevtoolsPlugin>>();
 

--- a/package.json
+++ b/package.json
@@ -24,12 +24,18 @@
   "author": "Mykola Mokhnach",
   "types": "./build/lib/index.d.ts",
   "files": [
-    "build",
-    "docs",
+    "build/lib",
     "lib",
-    "tsconfig.json",
-    "!build/tsconfig.tsbuildinfo"
+    "tsconfig.json"
   ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "prettier": {
     "bracketSpacing": false,
     "printWidth": 100,
@@ -39,14 +45,14 @@
     "build": "tsc -b",
     "clean": "npm run build -- --clean",
     "dev": "npm run build -- --watch",
-    "e2e-test": "mocha --exit --timeout 10m \"./test/e2e/**/*.e2e.spec.ts\"",
+    "e2e-test": "node --enable-source-maps --test --test-force-exit --test-concurrency=1 --test-timeout=600000 \"./build/test/e2e/**/*.e2e.spec.js\"",
     "format": "prettier --write \"**/*.{js,ts,json}\"",
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
     "lint:staged": "lint-staged",
     "prepare": "npm run rebuild",
     "rebuild": "npm run clean && npm run build",
-    "test": "mocha --exit --timeout 1m \"./test/unit/**/*.spec.ts\""
+    "test": "node --enable-source-maps --test --test-force-exit --test-timeout=60000 \"./build/test/unit/**/*.spec.js\""
   },
   "dependencies": {
     "axios": "^1.12.0",
@@ -81,18 +87,15 @@
     "@semantic-release/git": "^10.0.1",
     "@types/chai": "^5.2.3",
     "@types/express": "^5.0.3",
-    "@types/mocha": "^10.0.0",
     "@types/node": "^25.0.9",
     "@types/portscanner": "^2.1.4",
     "asyncbox": "^6.1.0",
     "chai": "^6.0.0",
     "chai-as-promised": "^8.0.0",
     "conventional-changelog-conventionalcommits": "^9.0.0",
-    "mocha": "^11.0.1",
     "prettier": "^3.0.1",
     "semantic-release": "^25.0.2",
     "sinon": "^22.0.0",
-    "ts-node": "^10.9.1",
     "typescript": "^6.0.3",
     "webdriverio": "^9.4.1"
   }

--- a/scripts/run-functional-tests.sh
+++ b/scripts/run-functional-tests.sh
@@ -3,4 +3,5 @@
 adb shell 'echo "chrome --disable-fre --no-default-browser-check --no-first-run" > /data/local/tmp/chrome-command-line'
 adb shell am set-debug-app --persistent com.android.chrome
 
-npx mocha ./test/e2e/**/*.e2e.spec.ts --exit --timeout 10m
+npm run build
+node --enable-source-maps --test --test-force-exit --test-concurrency=1 --test-timeout=600000 "./build/test/e2e/**/*.e2e.spec.js"

--- a/test/e2e/plugin.e2e.spec.ts
+++ b/test/e2e/plugin.e2e.spec.ts
@@ -1,3 +1,5 @@
+import {describe, it, beforeEach, afterEach} from 'node:test';
+
 import {remote as wdio} from 'webdriverio';
 import {waitForCondition} from 'asyncbox';
 import type {Browser} from 'webdriverio';
@@ -26,10 +28,10 @@ describe('DevtoolsPlugin', function () {
     }
   });
 
-  it('should list web views', async function () {
+  it('should list web views', async function (t) {
     if (process.env.CI) {
       // Not sure how to get rid of Chrome Welcome screen in the CI env
-      return this.skip();
+      return t.skip();
     }
 
     await driver.executeScript('mobile: startActivity', [

--- a/test/unit/plugin.spec.ts
+++ b/test/unit/plugin.spec.ts
@@ -1,4 +1,6 @@
-import {DevtoolsPlugin} from '../../lib/plugin';
+import {describe, it, beforeEach} from 'node:test';
+
+import {DevtoolsPlugin} from '../../lib/plugin.js';
 import {expect} from 'chai';
 
 describe('DevtoolsPlugin', function () {

--- a/test/unit/utils.spec.ts
+++ b/test/unit/utils.spec.ts
@@ -1,4 +1,6 @@
-import {replaceDeep} from '../../lib/utils';
+import {describe, it} from 'node:test';
+
+import {replaceDeep} from '../../lib/utils.js';
 import {expect} from 'chai';
 
 describe('utils', function () {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,13 +2,9 @@
   "compilerOptions": {
     "outDir": "build",
     "strict": true,
-    "types": ["node", "mocha"]
-  },
-  "ts-node": {
-    "transpileOnly": true,
-    "compilerOptions": {
-      "rootDir": "."
-    }
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"]
   },
   "extends": "@appium/tsconfig/tsconfig.plugin.json",
   "include": ["lib", "test"]


### PR DESCRIPTION
## Summary

- Converts appium-devtools-plugin from CommonJS to a native ESM package.
- Adds .js extensions to all relative imports and to the appium/plugin, appium/support, appium/driver subpath imports.
- Sets "type": "module" and adds an explicit exports map in package.json, restricting consumers to the package's public entry point (. and ./package.json).
- Enables module/moduleResolution: "NodeNext" in tsconfig.json.
- Replaces mocha + ts-node with Node's built-in test runner (node --test) run against the compiled build/test/** output, since ts-node's ESM loader story is not worth carrying forward. test/e2e-test npm scripts and scripts/run-functional-tests.sh updated accordingly; .mocharc.js removed.
- Fixes a WebSocket.Server type resolution break in lib/mixins/proxy.ts: @types/ws exposes different declarations for CJS vs ESM resolution modes, so the CJS-style WebSocket.Server namespace access no longer resolves under NodeNext. Switched to the named WebSocketServer export, with a narrow cast where the instance crosses into @appium/types's (still CJS-typed) addWebSocketHandler.

BREAKING CHANGE: appium-devtools-plugin is now an ESM-only package. It can no longer be loaded via CommonJS require(); consumers must use import or dynamic import(). Deep imports into the package's internals are no longer possible — only the public entry point is exposed via exports.
