### PR TITLE
feat: e2e coverage

### DIFF
--- a/lib/mixins/proxy.ts
+++ b/lib/mixins/proxy.ts
@@ -5,6 +5,7 @@ import type {BaseDriver} from 'appium/driver.js';
 import {util} from 'appium/support.js';
 import {findAPortNotInUse, checkPortStatus} from 'portscanner';
 import WebSocket, {WebSocketServer} from 'ws';
+import type {RawData} from 'ws';
 
 import {CDP_METHODS_ROOT} from '../constants.js';
 import type {DevtoolsPlugin} from '../plugin.js';
@@ -464,6 +465,17 @@ function prepareWebSocketForwarder(
         : forwardToUrlPattern;
     this.log.debug(`Will forward upstream ${req.url} to downstream ${dstUrl}`);
     const wsDownstream = new WebSocket(dstUrl);
+    // The downstream connection to the device takes time to establish. Any
+    // upstream message arriving while it is still connecting must be queued
+    // rather than dropped, since real CDP clients commonly send their first
+    // command right after the upstream socket opens.
+    const pendingUpstreamMessages: {msg: RawData; binary: boolean}[] = [];
+    wsDownstream.once('open', () => {
+      for (const {msg, binary} of pendingUpstreamMessages) {
+        wsDownstream.send(msg, {binary});
+      }
+      pendingUpstreamMessages.length = 0;
+    });
     wsDownstream.on('message', (msg, binary) => {
       if (wsUpstream.readyState === WebSocket.OPEN) {
         wsUpstream.send(msg, {binary});
@@ -472,6 +484,8 @@ function prepareWebSocketForwarder(
     wsUpstream.on('message', (msg, binary) => {
       if (wsDownstream.readyState === WebSocket.OPEN) {
         wsDownstream.send(msg, {binary});
+      } else if (wsDownstream.readyState === WebSocket.CONNECTING) {
+        pendingUpstreamMessages.push({msg, binary});
       }
     });
     wsDownstream.once('error', (e: Error) => {

--- a/test/e2e/plugin.e2e.spec.ts
+++ b/test/e2e/plugin.e2e.spec.ts
@@ -1,8 +1,11 @@
+import assert from 'node:assert/strict';
 import {describe, it, beforeEach, afterEach} from 'node:test';
 
 import {waitForCondition} from 'asyncbox';
+import axios from 'axios';
 import {remote as wdio} from 'webdriverio';
 import type {Browser} from 'webdriverio';
+import WebSocket from 'ws';
 
 const TEST_CAPS = {
   platformName: 'Android',
@@ -15,6 +18,60 @@ const WDIO_OPTS = {
   capabilities: TEST_CAPS,
 };
 
+const CHROME_PACKAGE = 'com.android.chrome';
+const CHROME_DEVTOOLS_SOCKET = '@chrome_devtools_remote';
+const TEST_PAGE_URL = 'https://example.com/';
+const TEST_PAGE_TITLE = 'Example Domain';
+
+interface DevtoolsPage {
+  id: string;
+  url: string;
+  title: string;
+  webSocketDebuggerUrl: string;
+}
+
+interface DevtoolsTarget {
+  name: string;
+  pages: DevtoolsPage[];
+  info: Record<string, any>;
+  isProxied: boolean;
+  proxyInfo: {uuid: string; alias: string; name: string; root: string} | null;
+}
+
+/**
+ * Sends a single Chrome DevTools Protocol command over the given websocket
+ * URL and resolves with its result. Used to prove that the plugin's websocket
+ * proxying works end to end, and not only its plain HTTP endpoints.
+ */
+function sendCdpCommand(wsUrl: string, method: string, params: Record<string, unknown> = {}): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const id = 1;
+    const ws = new WebSocket(wsUrl);
+    const timer = setTimeout(() => {
+      ws.terminate();
+      reject(new Error(`Timed out waiting for a response to '${method}'`));
+    }, 10000);
+    ws.once('open', () => ws.send(JSON.stringify({id, method, params})));
+    ws.once('error', (e) => {
+      clearTimeout(timer);
+      reject(e);
+    });
+    ws.on('message', (data) => {
+      const message = JSON.parse(data.toString());
+      if (message.id !== id) {
+        return;
+      }
+      clearTimeout(timer);
+      ws.close();
+      if (message.error) {
+        reject(new Error(message.error.message));
+      } else {
+        resolve(message.result);
+      }
+    });
+  });
+}
+
 describe('DevtoolsPlugin', function () {
   let driver: Browser;
 
@@ -24,33 +81,98 @@ describe('DevtoolsPlugin', function () {
 
   afterEach(async function () {
     if (driver) {
+      // Leave no tabs behind, so a repeated local run does not have to guess
+      // which of several same-URL tabs is the one it just opened.
+      await driver.execute('mobile: terminateApp', {appId: CHROME_PACKAGE}).catch(() => {});
       await driver.deleteSession();
     }
   });
 
-  it('should list web views', async function (t) {
-    if (process.env.CI) {
-      // Not sure how to get rid of Chrome Welcome screen in the CI env
-      return t.skip();
-    }
-
+  it('should discover, proxy and tear down a live Chrome devtools target', async function () {
+    // Start from a single-tab Chrome instance so the freshly opened page can
+    // be identified unambiguously, even on a device where Chrome's first-run
+    // experience (sign-in / notifications promo) is still being dismissed.
+    await driver.execute('mobile: shell', {command: 'am', args: ['force-stop', CHROME_PACKAGE]});
+    // On Android 13+, Chrome shows a notification-permission rationale dialog
+    // on its first launch unless POST_NOTIFICATIONS is already granted, in
+    // which case it skips the prompt entirely. Best-effort: the permission
+    // does not exist pre-Android 13 (the API level this plugin's CI targets),
+    // where this is a harmless no-op.
+    await driver
+      .execute('mobile: shell', {
+        command: 'pm',
+        args: ['grant', CHROME_PACKAGE, 'android.permission.POST_NOTIFICATIONS'],
+      })
+      .catch(() => {});
     await driver.executeScript('mobile: startActivity', [
       {
-        component: 'com.android.chrome/com.google.android.apps.chrome.Main',
-        uri: 'https://google.com',
+        component: `${CHROME_PACKAGE}/com.google.android.apps.chrome.Main`,
+        uri: TEST_PAGE_URL,
       },
     ]);
-    await waitForCondition(
+
+    const {target, pageId} = (await waitForCondition(
       async () => {
         const {targets} = (await driver.executeScript('devtools: listTargets', [])) as {
-          targets: any[];
+          targets: DevtoolsTarget[];
         };
-        return targets.length;
+        const chromeTarget = targets.find(({name}) => name === CHROME_DEVTOOLS_SOCKET);
+        const page = chromeTarget?.pages.find(({url, title}) => url === TEST_PAGE_URL && title === TEST_PAGE_TITLE);
+        return page ? {target: chromeTarget, pageId: page.id} : false;
       },
       {
-        waitMs: 5000,
-        intervalMs: 300,
+        waitMs: 30000,
+        intervalMs: 500,
       },
-    );
+    )) as unknown as {target: DevtoolsTarget; pageId: string};
+    assert.equal(target.isProxied, false);
+    assert.equal(target.proxyInfo, null);
+
+    const proxyInfo = (await driver.executeScript('devtools: proxyTarget', [{name: CHROME_DEVTOOLS_SOCKET}])) as {
+      uuid: string;
+      alias: string;
+      name: string;
+      root: string;
+    };
+    assert.equal(proxyInfo.name, CHROME_DEVTOOLS_SOCKET);
+    assert.match(proxyInfo.root, /^https?:\/\//);
+
+    try {
+      const {data: versionInfo} = await axios.get(`${proxyInfo.root}/json/version`);
+      assert.match(versionInfo.Browser, /^Chrome\//);
+      assert.ok(
+        versionInfo.webSocketDebuggerUrl.includes(proxyInfo.uuid),
+        `Expected the browser debugger URL to be rewritten to point back to the Appium server: ${versionInfo.webSocketDebuggerUrl}`,
+      );
+
+      const {data: pages} = await axios.get(`${proxyInfo.root}/json/list`);
+      const page = (pages as DevtoolsPage[]).find((p) => p.id === pageId);
+      assert.ok(page, `Expected a page with id '${pageId}' in ${JSON.stringify(pages)}`);
+      assert.equal(page.url, TEST_PAGE_URL);
+      assert.equal(page.title, TEST_PAGE_TITLE);
+      assert.ok(
+        page.webSocketDebuggerUrl.includes(proxyInfo.uuid),
+        `Expected the page debugger URL to be rewritten to point back to the Appium server: ${page.webSocketDebuggerUrl}`,
+      );
+
+      // Exercise the websocket proxy itself, not only the HTTP endpoints.
+      const evalResult = await sendCdpCommand(page.webSocketDebuggerUrl, 'Runtime.evaluate', {
+        expression: 'document.title',
+      });
+      assert.equal(evalResult.result.value, TEST_PAGE_TITLE);
+    } finally {
+      await driver.executeScript('devtools: unproxyTarget', [{name: CHROME_DEVTOOLS_SOCKET}]);
+    }
+
+    const {targets: targetsAfterUnproxy} = (await driver.executeScript('devtools: listTargets', [])) as {
+      targets: DevtoolsTarget[];
+    };
+    const targetAfterUnproxy = targetsAfterUnproxy.find(({name}) => name === CHROME_DEVTOOLS_SOCKET);
+    assert.ok(targetAfterUnproxy);
+    assert.equal(targetAfterUnproxy.isProxied, false);
+    assert.equal(targetAfterUnproxy.proxyInfo, null);
+
+    // The alias is gone once unproxied, so the old proxy root must stop responding.
+    await assert.rejects(axios.get(`${proxyInfo.root}/json/version`), (e: any) => e.response?.status === 404);
   });
 });


### PR DESCRIPTION
## Summary
- Add a real e2e "green path" test that drives the full plugin lifecycle against a live Chrome instance: `devtools: listTargets` → `devtools: proxyTarget` → hit the proxied `/json/version` and `/json/list` HTTP endpoints → send a live CDP command over the proxied websocket → `devtools: unproxyTarget` → verify the proxy is torn down (old root 404s). Runs unconditionally now; the previous test only checked `listTargets` and unconditionally skipped itself on CI ("Not sure how to get rid of Chrome Welcome screen").
- Fix a real race condition surfaced by that new websocket assertion: `prepareWebSocketForwarder` forwarded upstream (client) messages to the downstream (device) socket only when it was already `OPEN`, silently dropping anything sent while it was still `CONNECTING`. Since real CDP clients commonly send their first command immediately after the socket opens, this reliably dropped the first message. Fixed by queuing upstream messages while downstream is `CONNECTING` and flushing them once it's `open`.

## Why the test used to skip on CI
Chrome's first-run screens (sign-in prompt, and on Android 13+ a notification-permission rationale dialog) were assumed to block the devtools socket from coming up on a fresh CI emulator profile. Investigated and confirmed neither actually blocks it — the underlying CDP socket, target discovery, and proxying all work fine regardless of what's on screen:
- The sign-in screen is already suppressed by the `--disable-fre --no-first-run --no-default-browser-check` flags `scripts/run-functional-tests.sh` pushes via `chrome-command-line` before tests run.
- The notification rationale dialog only exists on Android 13+ and is skipped by Chrome itself once `POST_NOTIFICATIONS` is granted, so the test pre-grants it via `pm grant` (a no-op below Android 13, which is what CI's `apiLevel: 30` matrix entry runs).

No CI workflow/script changes were needed — the existing setup was already sufficient once the test stopped skipping and started using the fresh-profile-safe target/page matching (matching by page url *and* title, and by CDP page id rather than array position, to avoid picking a stale tab).